### PR TITLE
file selection and ignore changes

### DIFF
--- a/src/extension/PanelStateHandler.ts
+++ b/src/extension/PanelStateHandler.ts
@@ -3,6 +3,15 @@ import * as path from 'path';
 import * as fs from 'fs';
 import ignore from 'ignore';
 
+// Define the FileTreeItem interface
+interface FileTreeItem {
+    name: string;
+    path: string;
+    type: 'file' | 'directory';
+    hasChildren?: boolean;
+    children?: FileTreeItem[];
+}
+
 export class PanelStateHandler {
     private ig: ReturnType<typeof ignore> | null = null;
 
@@ -34,6 +43,9 @@ export class PanelStateHandler {
                 case 'copyToClipboard':
                     await vscode.env.clipboard.writeText(message.text);
                     break;
+                case 'getIgnoreInfo':
+                    await this.handleGetIgnoreInfo();
+                    break;
                 // Removed 'savePrompt' and 'loadPrompts' commands entirely
             }
         } catch (error) {
@@ -51,8 +63,10 @@ export class PanelStateHandler {
 
             this.setupIgnoreFilter(workspaceRoot);
 
-            // Load entire workspace root
+            // Build a full recursive file tree structure
             const tree = await this.buildFullFileTree(workspaceRoot, '');
+            
+            // Send the complete tree to the webview
             await this.webview.postMessage({
                 command: 'fileTree',
                 data: tree
@@ -130,57 +144,80 @@ export class PanelStateHandler {
     private setupIgnoreFilter(workspaceRoot: string) {
         const igInst = ignore();
         try {
-            const gitignorePath = path.join(workspaceRoot, '.gitignore');
-            if (fs.existsSync(gitignorePath)) {
-                const gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
-                igInst.add(gitignoreContent);
+            // First try .promptignore (takes precedence)
+            const promptignorePath = path.join(workspaceRoot, '.promptignore');
+            if (fs.existsSync(promptignorePath)) {
+                const promptignoreContent = fs.readFileSync(promptignorePath, 'utf8');
+                igInst.add(promptignoreContent);
+                console.log('Using .promptignore for file filtering');
+            } 
+            // Fall back to .gitignore if .promptignore doesn't exist
+            else {
+                const gitignorePath = path.join(workspaceRoot, '.gitignore');
+                if (fs.existsSync(gitignorePath)) {
+                    const gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
+                    igInst.add(gitignoreContent);
+                    console.log('Using .gitignore for file filtering (no .promptignore found)');
+                }
             }
+
+            // Always add common exclusions regardless of .promptignore or .gitignore
+            igInst.add([
+                'node_modules',
+                '.git',
+                'dist',
+                'out',
+                'build',
+                '.vscode',
+                '.idea',
+                '*.log'
+            ]);
         } catch (error) {
-            console.error('Error reading .gitignore:', error);
+            console.error('Error reading ignore file:', error);
         }
         this.ig = igInst;
     }
 
-    private async buildFullFileTree(dirPath: string, relativePath: string): Promise<any[]> {
-        const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dirPath));
-        let items: any[] = [];
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath || '';
-
-        for (const [name, type] of entries) {
-            const itemPath = path.join(relativePath, name);
-            const fullPath = path.join(dirPath, name);
-            const relativePathForIgnore = path.relative(workspaceRoot, fullPath);
-
-            if (this.ig && this.ig.ignores(relativePathForIgnore)) {
-                continue;
+    private async buildFullFileTree(dirPath: string, relativePath: string): Promise<FileTreeItem[]> {
+        try {
+            const result: FileTreeItem[] = [];
+            const files = await fs.promises.readdir(dirPath);
+            
+            for (const file of files) {
+                const fullPath = path.join(dirPath, file);
+                // Use relative path from workspace root for ignore checking
+                const itemRelPath = path.join(relativePath, file).replace(/\\/g, '/');
+                
+                // Skip if this path should be ignored
+                if (this.ig && this.ig.ignores(itemRelPath)) {
+                    continue;
+                }
+                
+                const stats = await fs.promises.stat(fullPath);
+                
+                if (stats.isDirectory()) {
+                    const children = await this.buildFullFileTree(fullPath, itemRelPath);
+                    result.push({
+                        name: file,
+                        path: itemRelPath,
+                        type: 'directory',
+                        hasChildren: children.length > 0,
+                        children: children
+                    });
+                } else {
+                    result.push({
+                        name: file,
+                        path: itemRelPath,
+                        type: 'file'
+                    });
+                }
             }
-
-            if (['node_modules', '.git', 'dist', '.vscode'].some(ignored => itemPath.includes(ignored))) {
-                continue;
-            }
-
-            const isDirectory = (type & vscode.FileType.Directory) !== 0;
-            const fileItem: any = {
-                name,
-                path: itemPath,
-                type: isDirectory ? 'directory' : 'file',
-                hasChildren: isDirectory
-            };
-
-            if (isDirectory) {
-                fileItem.children = await this.buildFullFileTree(path.join(dirPath, name), itemPath);
-            }
-
-            items.push(fileItem);
+            
+            return result;
+        } catch (error) {
+            console.error(`Error building file tree for ${dirPath}:`, error);
+            return [];
         }
-
-        // Sort directories first, then files
-        items.sort((a, b) => {
-            if (a.type === b.type) return a.name.localeCompare(b.name);
-            return a.type === 'directory' ? -1 : 1;
-        });
-
-        return items;
     }
 
     private async handleGetFileContent(files: string[]) {
@@ -236,40 +273,109 @@ export class PanelStateHandler {
                 throw new Error('No workspace folder found');
             }
 
-            const tree = await this.buildDirectoryTree(workspaceRoot, depth);
+            // Make sure ignore filter is set up
+            this.setupIgnoreFilter(workspaceRoot);
+
+            // Generate a tree structure with proper ignore filtering
+            const tree = await this.generateCodebaseTree(workspaceRoot, '', depth);
+            
             await this.webview.postMessage({
                 command: 'codebaseTree',
                 data: tree
             });
         } catch (error) {
-            vscode.window.showErrorMessage(`Error getting codebase tree: ${error}`);
+            console.error('Error generating codebase tree:', error);
+            vscode.window.showErrorMessage(`Error generating codebase tree: ${error}`);
         }
     }
 
-    private async buildDirectoryTree(dir: string, depth: number, currentDepth = 0): Promise<string> {
-        if (currentDepth >= depth) {
+    private async generateCodebaseTree(dirPath: string, relativePath: string, maxDepth: number, currentDepth: number = 0): Promise<string> {
+        if (currentDepth > maxDepth) {
             return '';
         }
 
-        let result = '';
-        const indent = '  '.repeat(currentDepth);
-        const files = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dir));
-
-        for (const [name, type] of files) {
-            if (name === 'node_modules' || name === '.git') {
-                continue;
+        try {
+            const files = await fs.promises.readdir(dirPath);
+            const items: string[] = [];
+            
+            for (const file of files) {
+                const fullPath = path.join(dirPath, file);
+                // Use relative path from workspace root for ignore checking
+                const itemRelPath = path.join(relativePath, file).replace(/\\/g, '/');
+                
+                // Skip if this path should be ignored
+                if (this.ig && this.ig.ignores(itemRelPath)) {
+                    continue; // Skip ignored files/directories
+                }
+                
+                try {
+                    const stats = await fs.promises.stat(fullPath);
+                    
+                    if (stats.isDirectory()) {
+                        if (currentDepth < maxDepth) {
+                            const subTree = await this.generateCodebaseTree(
+                                fullPath, 
+                                itemRelPath, 
+                                maxDepth, 
+                                currentDepth + 1
+                            );
+                            
+                            if (subTree) {
+                                items.push(`${file}/\n${subTree.split('\n').map(line => `  ${line}`).join('\n')}`);
+                            } else {
+                                items.push(`${file}/`);
+                            }
+                        } else {
+                            items.push(`${file}/`);
+                        }
+                    } else {
+                        items.push(file);
+                    }
+                } catch (error) {
+                    console.error(`Error accessing ${fullPath}:`, error);
+                }
             }
-
-            const fullPath = path.join(dir, name);
-            if (type === vscode.FileType.Directory) {
-                result += `${indent}📁 ${name}/\n`;
-                result += await this.buildDirectoryTree(fullPath, depth, currentDepth + 1);
-            } else {
-                result += `${indent}📄 ${name}\n`;
-            }
+            
+            // Sort items alphabetically, but with directories first
+            items.sort((a, b) => {
+                const aIsDir = a.endsWith('/');
+                const bIsDir = b.endsWith('/');
+                
+                if (aIsDir && !bIsDir) return -1;
+                if (!aIsDir && bIsDir) return 1;
+                return a.localeCompare(b);
+            });
+            
+            return items.join('\n');
+        } catch (error) {
+            console.error(`Error generating tree for ${dirPath}:`, error);
+            return '';
         }
+    }
 
-        return result;
+    private async handleGetIgnoreInfo() {
+        try {
+            const workspaceRoot = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+            if (!workspaceRoot) {
+                throw new Error('No workspace folder found');
+            }
+
+            const promptignorePath = path.join(workspaceRoot, '.promptignore');
+            const gitignorePath = path.join(workspaceRoot, '.gitignore');
+            
+            let message = '';
+            if (fs.existsSync(promptignorePath)) {
+                message = 'Using .promptignore for file filtering';
+            } else if (fs.existsSync(gitignorePath)) {
+                message = 'Using .gitignore for file filtering (no .promptignore found)';
+            } else {
+                message = 'No .promptignore or .gitignore found, using default exclusions only';
+            }
+
+            vscode.window.showInformationMessage(message);
+        } catch (error) {
+            console.error('Error getting ignore info:', error);
+        }
     }
 
     public dispose() {

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -102,6 +102,13 @@ window.addEventListener('load', () => {
             });
         }
 
+        const showIgnoreInfoBtn = document.getElementById('showIgnoreInfoBtn');
+        if (showIgnoreInfoBtn) {
+            showIgnoreInfoBtn.addEventListener('click', () => {
+                vscode.postMessage({ command: 'getIgnoreInfo' });
+            });
+        }
+
     } catch (error) {
         console.error('Failed to initialize webview:', error);
     }

--- a/src/webview/messages/handlers.ts
+++ b/src/webview/messages/handlers.ts
@@ -30,11 +30,9 @@ export class MessageHandler {
             
             switch (message.command) {
                 case 'fileTree': {
-                    const fileTreeData = {
-                        items: message.data,
-                        parentPath: ''
-                    };
-                    this.fileSelector.updateFileList(fileTreeData);
+                    console.log('Received file tree');
+                    // Update the file selector to show the full tree
+                    this.fileSelector.loadInitialFileTree(message.data);
                     break;
                 }
                     
@@ -95,4 +93,4 @@ export class MessageHandler {
             directoryPath
         });
     }
-} 
+}

--- a/src/webview/ui/components/promptEditor.ts
+++ b/src/webview/ui/components/promptEditor.ts
@@ -71,12 +71,12 @@ export class PromptEditor {
 
     private buildFinalPrompt(): string {
         const mainPrompt = this.promptInput.value;
-        let finalPrompt = `[Prompt Start]\n\n${mainPrompt}\n\n[Context]\n\n`;
+        let finalPrompt = `\n${mainPrompt}\n\n## Related files\n\n`;
 
         // Add selected files
         const fileEntries = Object.entries(this.currentContext.files);
         for (const [filePath, content] of fileEntries) {
-            finalPrompt += `- File: ${filePath}\n  Content:\n${content}\n\n`;
+            finalPrompt += `${filePath}:\n\`\`\`\n${content}\n\`\`\`\n\n`;
         }
 
         // Add codebase tree only if it exists and is enabled
@@ -85,7 +85,7 @@ export class PromptEditor {
             finalPrompt += `- Codebase Tree:\n${this.currentContext.treeStructure}\n\n`;
         }
 
-        finalPrompt += `[End of Context]\n`;
+        finalPrompt += `\n`;
 
         return finalPrompt;
     }
@@ -176,7 +176,7 @@ export class PromptEditor {
         
         const header = document.createElement('div');
         header.className = 'tree-header';
-        header.innerHTML = '<span class="tree-icon">🌳</span> Codebase Tree';
+        header.innerHTML = '## Codebase Tree';
         treeBlock.appendChild(header);
         
         const contentDiv = document.createElement('div');

--- a/src/webview/ui/styles.ts
+++ b/src/webview/ui/styles.ts
@@ -104,7 +104,7 @@ export function getStyles(): string {
             top: 100%;
             left: 0;
             right: 0;
-            max-width: 300px;
+            max-width: 500px; /* Increase from 300px */
             background: var(--vscode-dropdown-background);
             border: 1px solid var(--vscode-dropdown-border);
             z-index: 1000;
@@ -280,4 +280,4 @@ export function getStyles(): string {
             color: var(--vscode-textPreformat-foreground);
         }
     `;
-} 
+}

--- a/src/webview/ui/template.ts
+++ b/src/webview/ui/template.ts
@@ -19,6 +19,7 @@ export function getWebviewContent(nonce: string, scriptUri: string): string {
                 <input type="text" id="fileSearch" placeholder="Search files by name" autocomplete="off">
                 <button id="reloadFilesBtn">Refresh Files</button>
                 <button id="clearFilesBtn">Clear all files</button>
+                <button id="showIgnoreInfoBtn" title="Shows which ignore file is being used">Ignore Info</button>
                 <div class="dropdown" id="fileDropdown"></div>
             </div>
             <div class="selected-files" id="selectedFiles"></div>


### PR DESCRIPTION
Your extension is awesome! However, I had some issues with it:

- The prompt format with bracketing was working fine enough, but ChatGPT models seemed to choke on it sometimes, getting confused. I ended up using regex to replace the bracketed section names and add fenced backticks around code blocks, and I removed all the folder icons. And that seemed to solve the issue, but it's a lot of manual processing. Both your format and mine seem to work equally well with other model families; just ChatGPT struggled sometimes with yours. I HAVE NO IDEA WHY.
- Folders in the file selector weren't expanding to show file contents. I had to click "select all" for the folder then remove what I didn't want. Dunno if they used to and just got broken by a vscode update or something.
- Using `.gitignore` for file select filtering meant I wasn't able to select test data files to add to the prompt without having to comment/uncomment them constantly. I figure this is a pretty common use case.
- Including Codebase Tree added just way too many files for my project because of reference files and stuff.

I saw that maybe you weren't maintaining this anymore, so I just forked it and used AI (claude 3.7 sonnet [thinking]) to make the changes I wanted. They seem to be working pretty well. I'm sharing them with you suggestively; I didn't do any manual review or cleanup or anything. But, if you just wanted to eat them for your own use. :)

Also, sorry for the single commit; my fork has separated commits, but the issues were addressed across commits anyway, so no point sharing them. 

Here's what I changed:

- **Folder expansion for file selection**
  - Folders now expand and collapse (again?) and show their contents
  - Folders expanded by default
  - Expand/Collapse toggle added next to the selection-close `X` button.
- **Ignore changes**
  - Now uses `.promptignore` instead of `.gitignore`.
  - Codebase Tree now respects `.promptignore` when generating the tree structure.
- **Prompt format to GFM**
  - Removed `[PROMPT START]` and changed `[CONTEXT START/END]`  to just `## Related Files`
  - Removed file label and wrapped code blocks in fenced backticks.
  - Removed Codebase Tree icons and added md header. 
  
 ## What the new prompt format looks like
  
````markdown
Please just fix everything and make it better so I can focus on this Netflix show I'm watching.

## Related files

src/webview/index.ts:
```
// Initialize VSCode API
declare function acquireVsCodeApi(): any;

import { FileSelector } from './ui/components/fileSelector';
import { CodebaseTree } from './ui/components/codebaseTree';
import { PromptEditor } from './ui/components/promptEditor';
import { MessageHandler } from './messages/handlers';

window.addEventListener('load', () => {
    try {
        console.log('Initializing webview...');
        const vscode = acquireVsCodeApi();

        const promptInput = document.getElementById('promptInput');
        const contextArea = document.getElementById('contextArea');
        const tokenCount = document.getElementById('tokenCount');

        if (!promptInput || !contextArea || !tokenCount) {
            console.error('Required DOM elements not found:', {
                promptInput: !!promptInput,
                contextArea: !!contextArea,
                tokenCount: !!tokenCount
            });
            return;
        }

        console.log('DOM elements found, initializing components...');

        const fileSelector = new FileSelector(
            vscode,
            (files: string[]) => {
                console.log('Files selected:', files);
                // When files change, request their content and update prompt editor
                if (files.length > 0) {
                    vscode.postMessage({ 
                        command: 'getFileContent', 
                        files 
                    });
                } else {
                    // If no files selected, clear the context
                    promptEditor.updateContext({
                        files: {},
                        treeStructure: codebaseTree.getTreeStructure()
                    });
                }
            }
        );

        // When tree config changes, we now request the codebase tree from backend
        const codebaseTree = new CodebaseTree(
            (include, depth) => {
                console.log('Tree config changed:', { include, depth });
                if (include) {
                    vscode.postMessage({ command: 'getCodebaseTree', depth });
                }
            }
        );

        const promptEditor = new PromptEditor(
            (prompt) => {
                console.log('Prompt changed:', prompt);
            },
            codebaseTree,
            vscode
        );

        codebaseTree['promptEditor'] = promptEditor;

        const messageHandler = new MessageHandler(
            vscode,
            fileSelector,
            codebaseTree,
            promptEditor,
        );

        console.log('Components initialized successfully');

        messageHandler.sendMessage({ command: 'getFileTree' });
        messageHandler.sendMessage({ command: 'loadPrompts' });

        const refreshBtn = document.getElementById('reloadFilesBtn');
        if (refreshBtn) {
            refreshBtn.addEventListener('click', () => {
                // First refresh the file tree
                vscode.postMessage({ command: 'getFileTree' });
                
                // Then refresh content of currently selected files
                const selectedFiles = fileSelector.getSelectedFiles();
                if (selectedFiles.length > 0) {
                    vscode.postMessage({
                        command: 'getFileContent',
                        files: selectedFiles
                    });
                }
            });
        }

        const clearBtn = document.getElementById('clearFilesBtn');
        if (clearBtn) {
            clearBtn.addEventListener('click', () => {
                fileSelector.clearAllSelectedFiles();
            });
        }

        const showIgnoreInfoBtn = document.getElementById('showIgnoreInfoBtn');
        if (showIgnoreInfoBtn) {
            showIgnoreInfoBtn.addEventListener('click', () => {
                vscode.postMessage({ command: 'getIgnoreInfo' });
            });
        }

    } catch (error) {
        console.error('Failed to initialize webview:', error);
    }
});
```

- Codebase Tree:
.cursorrules
.vscodeignore
CHANGELOG.md
DETAILS.md
LICENSE.md
package-lock.json
package.json
README.md
src/
  extension.ts
  extension/
    PanelStateHandler.ts
  webview/
    messages/
    state/
    ui/
    index.ts
    messageTypes.ts
    panel.ts
    promptLibrary.ts
    tokenCounter.ts
tsconfig.json
webpack.config.js
````